### PR TITLE
feat: orderByDeps recognises relative dependencies

### DIFF
--- a/fixture/packages/b/package.json
+++ b/fixture/packages/b/package.json
@@ -2,6 +2,6 @@
   "name": "b",
   "version": "1.0.0",
   "devDependencies": {
-    "c": "^1.0.0"
+    "c": "file:../c"
   }
 }

--- a/src/utils/workspaces.ts
+++ b/src/utils/workspaces.ts
@@ -10,6 +10,8 @@ import {
 	dependencyTypes,
 } from "../types"
 
+const localPrefixes = ["file:", "workspace:"]
+
 export function arrify<T>(value: undefined | T | T[]): T[] {
 	if (typeof value === "undefined") {
 		return []
@@ -30,6 +32,12 @@ function matchesPatterns(
 	} else {
 		return mm.any(str, patterns)
 	}
+}
+
+function matchesDependency(match: Workspace, depVersion: string): boolean {
+	const versionMatch = semver.satisfies(match.config.version, depVersion)
+	const localDep = localPrefixes.some(prefix => depVersion.startsWith(prefix))
+	return versionMatch || localDep
 }
 
 export async function getFilteredWorkspaces(
@@ -89,7 +97,7 @@ export function getWorkspaceGraph(
 					continue
 				}
 
-				if (!semver.satisfies(match.config.version, depVersion)) {
+				if (!matchesDependency(match, depVersion)) {
 					continue
 				}
 


### PR DESCRIPTION
As https://github.com/jamiebuilds/workspaces-run/issues/4 this changes getWorkspaceGraph to recognise dependencies using relative dependency versions (i.e. `file:` from npm and `workspace:` from pnpm).